### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,7 @@
 Changes
 =======
 
-2.2 (unreleased)
+3.0 (unreleased)
 ----------------
 
 * Drop support for Python 3.8.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ Changes
 3.0 (unreleased)
 ----------------
 
+* Replace ``pkg_resources`` namespace with PEP 420 native namespace.
+
 * Drop support for Python 3.8.
 
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ long_description = (
 
 setup(
     name='z3c.unconfigure',
-    version='2.2.dev0',
+    version='3.0.dev0',
     description=("Disable specific ZCML directives in other package's "
                  "configuration"),
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -38,9 +37,6 @@ setup(
         'Programming Language :: Python :: 3.13',
     ],
 
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    namespace_packages=['z3c'],
     include_package_data=True,
     zip_safe=False,
     python_requires='>=3.9',

--- a/src/z3c/__init__.py
+++ b/src/z3c/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
